### PR TITLE
added support for search counts per year / month

### DIFF
--- a/open_budget_search_api/config.py
+++ b/open_budget_search_api/config.py
@@ -3,12 +3,8 @@ import elasticsearch
 
 ES_HOST = os.environ.get('ES_HOST', 'localhost')
 ES_PORT = os.environ.get('ES_PORT', '9200')
-
-es_connection_string = '{}:{}'\
-    .format(ES_HOST, ES_PORT)
-
 INDEX_NAME = os.environ.get('INDEX_NAME', 'budgetkey')
-ES_SERVERS_LIST = [ES_HOST]
+ES_SERVERS_LIST = [{"host": ES_HOST, "port": int(ES_PORT)}]
 DEFAULT_TIMEOUT = 60
 
 SEARCHABLE_DATAPACKAGES = [

--- a/open_budget_search_api/data_source.py
+++ b/open_budget_search_api/data_source.py
@@ -26,12 +26,10 @@ class DataSource(object):
 
         self.date_fields = {}
         self.range_structure = {}
-        for range_kw, operator in [('from', 'gte'), ('to', 'lte')]:
-            for field in fields:
-                if range_kw in field.get('search:time-range', ''):
-                    self.date_fields[range_kw] = field['name']
-                    self.range_structure.setdefault(field['name'], {})[operator] = range_kw + '_date'
-        self.is_temporal = False  # len(self.date_fields) > 0
+
+        for field in fields:
+            if field.get("es:time-range"):
+                self.date_fields[field["es:time-range"]] = field["name"]
 
         try:
             self.scoring_column = next(iter(


### PR DESCRIPTION
* related issue: #16 
* added search counts, based on the `es:time-range` field
* following `es:time-range` values are supported
  * `from` - used to get total per month
  * `year` - specific year (as integer) converted to total per year
* fixed elasticsearch connection - allow to set port